### PR TITLE
Bump version number

### DIFF
--- a/version.php
+++ b/version.php
@@ -23,7 +23,7 @@
  */
 defined ( 'MOODLE_INTERNAL' ) || die ();
 
-$plugin->version = 2022080500;
+$plugin->version = 2022100600;
 $plugin->requires = 2019111800;
 $plugin->supported = [38, 400]; // Moodle 3.8, 3.9, 3.10, 3.11 and 4.0 suported and tested.
 $plugin->component = 'assignsubmission_snap';


### PR DESCRIPTION
The variable `$plugin->version` should be increased in `version.php` to allow update from previous versions.